### PR TITLE
Set default-directory for local-custom expansion

### DIFF
--- a/init-helpers/quick-init-helpers.el
+++ b/init-helpers/quick-init-helpers.el
@@ -1,7 +1,7 @@
 (defun init-set-custom ()
   "Custom set and loaded from local (non-git) or regular (git-shared)"
   (let ((default-directory user-emacs-directory)
-        (local-custom (expand-file-name "local/custom.el")))
+        (local-custom (expand-file-name "local/custom.el" user-emacs-directory)))
     (if (file-readable-p local-custom)
         (setq custom-file local-custom)
       (setq custom-file (expand-file-name "custom/custom.el")))


### PR DESCRIPTION
I'm assuming that since local-custom is being set up in the let it's not
set when expand-file-name is used to configure the path to the local
custom.el.

The value set is equivalent to ~/local/custom.el. And local-custom is
set to ~/ before it's replaced with user-emacs-directory.

I was a bit unsure how to solve this in the cleanest way, making a nested let didn't feel like it…
